### PR TITLE
6 add specializations for adaptable connections

### DIFF
--- a/sandbox/CMakeLists.txt
+++ b/sandbox/CMakeLists.txt
@@ -1,10 +1,10 @@
 ﻿# does not compile with asio 1.12
 
-#add_executable(sandbox sandbox/sandbox.cpp)
-#target_link_libraries(sandbox PRIVATE eld::asio_utils)
+add_executable(sandbox sandbox.cpp)
+target_link_libraries(sandbox PRIVATE eld::asio_utils)
 
-#add_executable(sb.find_deadlock sandbox/find_deadlock.cpp)
+#add_executable(sb.find_deadlock find_deadlock.cpp)
 #target_link_libraries(sb.find_deadlock PRIVATE eld::asio_utils)
 
-#add_executable(example_6 sandbox/example_6.cpp)
+#add_executable(example_6 example_6.cpp)
 #target_link_libraries(example_6 PRIVATE eld::asio_utils)

--- a/sandbox/sandbox.cpp
+++ b/sandbox/sandbox.cpp
@@ -1,7 +1,7 @@
 ﻿
-#include "asio_utils/testing/test_utils.h"
 #include "asio_utils/connection_adapter.hpp"
 #include "asio_utils/connection_tools.hpp"
+#include "asio_utils/testing/test_utils.h"
 
 #include <numeric>
 
@@ -46,18 +46,20 @@ int main()
     struct StubConnectionA
     {
         using config_type = double;
-        void cancel(){}
-
+        void cancel() {}
     };
 
     struct StubConnectionB
     {
         using config_type = double;
-        void cancel(){}
-
+        void cancel() {}
     };
 
+    asio::io_context ioContext;
+
     auto adapter = eld::make_connection_adapter(StubConnectionA(), StubConnectionB());
+    auto tcpUdpAdapter = eld::make_connection_adapter(asio::ip::udp::socket(ioContext),
+                                                      asio::ip::tcp::socket(ioContext));
 
     return 0;
 }


### PR DESCRIPTION
- Implemented specializations for asio udp, tcp and serial port. Implemented single test for tcp -> udp transfer, which occasionally throws error "Only one usage of each socket address (protocol/network address/port) is normally permitted.".  
- fixed implementation for  connection adapter, though its logic has to be fixed (previous user's continuation must be called on repeated calls to `async_run` with different configs).